### PR TITLE
Update jupyterlab-vim to active fork

### DIFF
--- a/extensions.tpl
+++ b/extensions.tpl
@@ -28,7 +28,7 @@ This a list of nice JupyterLab extensions not part of ``jupyterlab-contrib`` org
 - [LaTeX](https://github.com/jupyterlab/jupyterlab-latex): An extension for JupyterLab which allows for live-editing of LaTeX documents.
 - [jupyterlab_markup](https://github.com/agoose77/jupyterlab-markup): JupyterLab extension to enable **markdown-it** rendering, with support for markdown-it plugins
 - [Table of Contents](https://github.com/jupyterlab/jupyterlab-toc): [Built-in since v3] Generates a table of content for your notebook and markdown documents.
-- [Vim](https://github.com/jwkvam/jupyterlab-vim): Notebook cell vim bindings.
+- [Vim](https://github.com/axelfahy/jupyterlab-vim): Notebook cell vim bindings.
 
 ### UI enhancement
 


### PR DESCRIPTION
The original jupyterlab-vim seems to have been abandoned. Axelfahy's fork is actively developed and works on Jlab 2 and 3