### PR TITLE
Add jupyter-stack-trace extension.

### DIFF
--- a/extensions.tpl
+++ b/extensions.tpl
@@ -52,7 +52,7 @@ This a list of nice JupyterLab extensions not part of ``jupyterlab-contrib`` org
   - [jupyterlab-unfold](https://github.com/martinRenou/jupyterlab-unfold): Tree view files browser.
   - [jupyterlab_filetree](https://github.com/youngthejames/jupyterlab_filetree): File Tree view for jupyterlab.
   - [jupyter-fs](https://github.com/jpmorganchase/jupyter-fs) - A filesystem-like contents manager for multiple backends in Jupyter
-- [jupyter-stack-trace](https://github.com/teticio/jupyter-stack-trace): Jump to the line in the file of the stack trace.
+- [jupyter-stack-trace](https://github.com/teticio/jupyter-stack-trace): Jump to the line in the file of the stack trace, search Google for the error in Stack Overflow, or ask Bing Chat for help.
 
 ### Viewers / Renderers
 

--- a/extensions.tpl
+++ b/extensions.tpl
@@ -52,6 +52,7 @@ This a list of nice JupyterLab extensions not part of ``jupyterlab-contrib`` org
   - [jupyterlab-unfold](https://github.com/martinRenou/jupyterlab-unfold): Tree view files browser.
   - [jupyterlab_filetree](https://github.com/youngthejames/jupyterlab_filetree): File Tree view for jupyterlab.
   - [jupyter-fs](https://github.com/jpmorganchase/jupyter-fs) - A filesystem-like contents manager for multiple backends in Jupyter
+- [jupyter-stack-trace](https://github.com/teticio/jupyter-stack-trace): Jump to the line in the file of the stack trace.
 
 ### Viewers / Renderers
 

--- a/migrate_from_classical.md
+++ b/migrate_from_classical.md
@@ -32,6 +32,7 @@ to [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/).
 | [Export Embedded HTML](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/export_embedded/readme.html) |  |  |
 | [Freeze](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/freeze/readme.html) |  |  |
 | [Gist-it](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/gist_it/readme.html) |  |  |
+| [Goto Error](https://github.com/teticio/nbextension-gotoerror) | [jupyter-stack-trace](https://github.com/teticio/jupyter-stack-trace) extension | 3+ |
 | [Help panel](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/help_panel/readme.html) | Built-in feature (Help entries open in panels) | 1+ |
 | [Hide Header](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/hide_header/README.html) | Built-in feature (View -> Simple interface) | 1+ |
 | [Hide input](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/hide_input/readme.html) | Built-in feature (View -> Collapse Selected Code) | 1+ |


### PR DESCRIPTION
Hi

I added [jupyter-stack-trace](https://github.com/teticio/jupyter-stack-trace) - an extension that allows you to click on a item in the stack trace and open up the file on the relevant line. It also adds a "Search Stack Overflow" button.

It is a migration of a classic notebook extension I wrote some time ago (Goto Error).

Thanks!