### PR TITLE
Remove link to jupyterlab-vim from the "elsewhere" section

### DIFF
--- a/extensions.tpl
+++ b/extensions.tpl
@@ -35,7 +35,6 @@ This a list of nice JupyterLab extensions not part of ``jupyterlab-contrib`` org
 - [jupyterlab_markup](https://github.com/agoose77/jupyterlab-markup): JupyterLab extension to enable **markdown-it** rendering, with support for markdown-it plugins
 - [jupyterlab_myst](https://github.com/executablebooks/jupyterlab-myst): JupyterLab extension to enable [MyST Markdown](https://mystmd.org) rendering
 - [Table of Contents](https://github.com/jupyterlab/jupyterlab-toc): [Built-in since v3] Generates a table of content for your notebook and markdown documents.
-- [Vim](https://github.com/axelfahy/jupyterlab-vim): Notebook cell vim bindings.
 
 ### UI enhancement
 


### PR DESCRIPTION
The jupyterlab-vim repo was moved into the organization, and the link in the "elsewhere" section actually redirects to the repo within the organization. The entry in the "elsewhere" section is therefore a duplicate of the info page in the "extensions in this organization" list.